### PR TITLE
Allows optional email and adds email actions for guests

### DIFF
--- a/app/Domains/Guests/Models/Guest.php
+++ b/app/Domains/Guests/Models/Guest.php
@@ -23,7 +23,7 @@ use Illuminate\Support\Carbon;
  * @property-read string $name
  * @property string $first_name
  * @property string|null $last_name
- * @property string $email (Unique)
+ * @property string|null $email (Unique)
  * @property string|null $phone_number
  * @property bool $has_registered
  * @property bool $email_sent

--- a/app/Http/Controllers/SaveAnswersController.php
+++ b/app/Http/Controllers/SaveAnswersController.php
@@ -52,10 +52,9 @@ class SaveAnswersController extends Controller
                 );
             }
 
-            if (true === $guest->email_sent) {
+            if ($guest->email_sent === true) {
                 return;
             }
-
 
             if ($guest->events->isNotEmpty()) {
                 Mail::to($guest->email)


### PR DESCRIPTION
Updates Guest model to make email nullable, accommodating guests without email.
Adds an email action in the Guest resource for sending confirmations, considering
event participation and prior email delivery status. Enhances admin interface
by including notifications for email status and introducing force-send option.

Aligns the email logic in SaveAnswersController for consistency.
